### PR TITLE
add list operations

### DIFF
--- a/rediserver/redis.py
+++ b/rediserver/redis.py
@@ -13,6 +13,7 @@ class KeyType:
 
 MUTABLE_KEY = object()
 KEY_SET = KeyType(set)
+KEY_LIST = KeyType(list)
 KEY_STRING = KeyType(bytes)
 
 
@@ -170,6 +171,8 @@ class Redis:
     def execute_sadd(self, key: (MUTABLE_KEY, KEY_SET), *args):
         if key not in self.keys:
             self.keys[key] = set()
+        elif not type(self.keys[key]) is set:
+            return resp.Errors.WRONGTYPE
 
         values = self.keys[key]
         to_add = set(args) - values
@@ -180,6 +183,8 @@ class Redis:
     def execute_spop(self, key: (MUTABLE_KEY, KEY_SET)):
         if key not in self.keys:
             return resp.NIL
+        if not type(self.keys[key]) is set:
+            return resp.Errors.WRONGTYPE
         values = self.keys[key]
         result = values.pop()
 
@@ -192,6 +197,8 @@ class Redis:
     def execute_scard(self, key: KEY_SET):
         if key not in self.keys:
             return 0
+        if not type(key) is set:
+            return resp.Errors.WRONGTYPE
         return len(self.keys[key])
 
     @redis_command('EVALSHA')
@@ -226,3 +233,329 @@ class Redis:
 
         if not isinstance(self.keys[key], type_):
             raise resp.Errors.WRONGTYPE
+
+    # ------------------------------------------------------------------
+    # List-based commands
+    @redis_command('LINDEX')
+    def execute_lindex(self, key: (MUTABLE_KEY, KEY_LIST), index: int):
+        """
+        Returns the element at index index in the list stored at key. The
+        index is zero-based, so 0 means the first element, 1 the
+        second element and so on. Negative indices can be used to
+        designate elements starting at the tail of the list. Here, -1
+        means the last element, -2 means the penultimate and so forth.
+
+        When the value at key is not a list, an error is returned.
+
+        Return value:
+          Bulk string reply: the requested element, or nil when index
+          is out of range.
+        """
+        if not key in self.keys:
+            return resp.Errors.KEYERROR
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        if abs(index) > (len(self.keys[key]) - 1):
+            return resp.NIL
+        index = index % len(self.keys[key])
+        return self.keys[key][index]
+
+    @redis_command('LINSERT')
+    def execute_linsert(self, key: (MUTABLE_KEY, KEY_LIST), befaft: str, pivot, value):
+        """
+        Inserts value in the list stored at key either before or after the
+        reference value pivot. When key does not exist, it is
+        considered an empty list and no operation is performed. An
+        error is returned when key exists but does not hold a list
+        value.
+
+        Return value:
+          Integer reply: the length of the list after the insert
+          operation, or -1 when the value pivot was not found.
+        """
+        if not key in self.keys:
+            return resp.NIL
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        if not type(befaft) is str:
+            return resp.Error('WRONGTYPE', 'First argument must be "BEFORE|AFTER"')
+        befaft = befaft.lower()
+        if not befaft in ('before', 'after'):
+            return resp.Error('UNKCMD', 'Unrecognized direction, must be "BEFORE|AFTER"')
+        try:
+            index = self.keys[key].index(pivot) + (befaft == 'after')
+        except ValueError:
+            return resp.NIL
+        self.keys[key].insert(index, value)
+        return len(self.keys[key])
+
+    @redis_command('LLEN')
+    def execute_llen(self, key: (MUTABLE_KEY, KEY_LIST)):
+        """
+        Returns the length of the list stored at key. If key does not
+        exist, it is interpreted as an empty list and 0 is returned.
+        An error is returned when the value stored at key is not a
+        list.
+    
+        Return value:
+          Integer reply: the length of the list at key.
+        """
+        if not key in self.keys:
+            return 0
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        return len(self.keys[key])
+
+    @redis_command('LPOP')
+    def execute_lpop(self, key: (MUTABLE_KEY, KEY_LIST)):
+        """
+        Removes and returns the first element of the list stored at key.
+
+        Return value:
+          Bulk string reply: the value of the first element, or nil
+          when key does not exist.
+        """
+        if not key in self.keys:
+            return resp.NIL
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        if self.keys[key]:
+            return self.keys[key].pop(0)
+        else:
+            return resp.NIL
+
+    @redis_command('LPUSH')
+    def execute_lpush(self, key: (MUTABLE_KEY, KEY_LIST), *args):
+        """
+        Insert all the specified values at the head of the list stored at
+        key. If key does not exist, it is created as empty list before
+        performing the push operations. When key holds a value that is
+        not a list, an error is returned.
+    
+        It is possible to push multiple elements using a single
+        command call just specifying multiple arguments at the end of
+        the command. Elements are inserted one after the other to the
+        head of the list, from the leftmost element to the rightmost
+        element. So for instance the command LPUSH mylist a b c will
+        result into a list containing c as first element, b as second
+        element and a as third element.
+    
+        Return value:
+          Integer reply: the length of the list after the push
+          operations.
+        """
+        if not key in self.keys:
+            self.keys[key] = list()
+        elif not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        self.keys[key] = list(args) + self.keys[key]
+        return len(self.keys[key])
+
+    @redis_command('LPUSHX')
+    def execute_lpushx(self, key: (MUTABLE_KEY, KEY_LIST), *args):
+        """
+        Inserts value at the head of the list stored at key, only if key
+        already exists and holds a list. In contrary to LPUSH, no
+        operation will be performed when key does not yet exist.
+
+        Return value:
+          Integer reply: the length of the list after the push
+          operation.
+        """
+        if not key in self.keys:
+            return resp.NIL
+        self.execute_lpush(key, *args)
+
+    @redis_command('LRANGE')
+    def execute_lrange(self, key: (MUTABLE_KEY, KEY_LIST), start: int, stop: int):
+        """
+        Returns the specified elements of the list stored at key. The
+        offsets start and stop are zero-based indexes, with 0 being
+        the first element of the list (the head of the list), 1 being
+        the next element and so on.
+
+        These offsets can also be negative numbers indicating offsets
+        starting at the end of the list. For example, -1 is the last
+        element of the list, -2 the penultimate, and so on.
+
+        Out of range indexes will not produce an error. If start is
+        larger than the end of the list, an empty list is returned. If
+        stop is larger than the actual end of the list, Redis will
+        treat it like the last element of the list.
+
+        Return value:
+          Array reply: list of elements in the specified range.
+        """
+        if not key in self.keys:
+            return resp.NIL
+        elif not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+
+        l = len(self.keys[key])
+        if start < 0:
+            start = max(0, l + start)
+        if stop < 0:
+            stop = max(0, l + stop)
+        return self.keys[key][ start:(stop + 1) ]
+
+    @redis_command('LREM')
+    def execute_lrem(self, key: (MUTABLE_KEY, KEY_LIST), count: int, value):
+        """
+        Removes the first count occurrences of elements equal to value
+        from the list stored at key. The count argument influences the
+        operation in the following ways:
+
+            count > 0: Remove elements equal to value moving from head to tail.
+            count < 0: Remove elements equal to value moving from tail to head.
+            count = 0: Remove all elements equal to value.
+        
+        For example, LREM list -2 "hello" will remove the last two
+        occurrences of "hello" in the list stored at list.
+        
+        Note that non-existing keys are treated like empty lists, so
+        when key does not exist, the command will always return 0.
+        
+        Return value:
+          Integer reply: the number of removed elements.
+        """
+        if not key in self.keys:
+            return 0
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        indices = [ i for i,x in enumerate(self.keys[key]) if x == value ]
+        if len(indices) == 0:
+            return 0
+        if count < 0:
+            indices = indices[count:]
+        elif count > 0:
+            indices = indices[:count]
+        for i in sorted(indices, reverse=True):
+            del(self.keys[key][ i ])
+        return len(indices)
+        
+    @redis_command('LSET')
+    def execute_lset(self, key: (MUTABLE_KEY, KEY_LIST), index: int, value):
+        """
+        Sets the list element at index to value. For more information on
+        the index argument, see LINDEX.
+        
+        An error is returned for out of range indexes.
+
+        Return value:
+          Simple string reply
+        """
+        if not key in self.keys:
+            return resp.Errors.KEYERROR
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        if abs(index) > (len(self.keys[key]) - 1):
+            return resp.Errors.NOT_INT
+        index = index % len(self.keys[key])
+        self.keys[key][index] = value
+        return resp.OK
+
+    @redis_command('LTRIM')
+    def execute_ltrim(self, key: (MUTABLE_KEY, KEY_LIST), start: int, stop: int):
+        """
+        Trim an existing list so that it will contain only the specified
+        range of elements specified. Both start and stop are
+        zero-based indexes, where 0 is the first element of the list
+        (the head), 1 the next element and so on.
+
+        Return value:
+          Simple string reply
+        """
+        l = len(self.keys[key])
+        if start < 0:
+            start = max(0, l + start)
+        if stop < 0:
+            stop = max(0, l + stop)
+        self.keys[key] = self.keys[key][ start:(stop + 1) ]
+        return resp.OK
+
+    @redis_command('RPOP')
+    def execute_rpop(self, key: (MUTABLE_KEY, KEY_LIST)):
+        """
+        Removes and returns the last element of the list stored at key.
+
+        Return value:
+          Bulk string reply: the value of the last element, or nil
+          when key does not exist.
+        """
+        if not key in self.keys:
+            return resp.NIL
+        if not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        if not self.keys[key]:
+            return resp.NIL
+        return self.keys[key].pop()
+
+    @redis_command('RPOPLPUSH')
+    def execute_rpoplpush(self, source: (MUTABLE_KEY, KEY_LIST), destination: (MUTABLE_KEY, KEY_LIST)):
+        """
+        Atomically returns and removes the last element (tail) of the list
+        stored at source, and pushes the element at the first element
+        (head) of the list stored at destination.
+
+        For example: consider source holding the list a,b,c, and
+        destination holding the list x,y,z. Executing RPOPLPUSH
+        results in source holding a,b and destination holding c,x,y,z.
+
+        If source does not exist, the value nil is returned and no
+        operation is performed. If source and destination are the
+        same, the operation is equivalent to removing the last element
+        from the list and pushing it as first element of the list, so
+        it can be considered as a list rotation command.
+
+        Return value:
+          Bulk string reply: the element being popped and pushed.
+        """
+        if not source in self.keys or not destination in self.keys:
+            return resp.NIL
+        if not type(self.keys[source]) is list or not type(self.keys[destination]) is list:
+            return resp.Errors.WRONGTYPE
+        value = self.keys[source].pop()
+        self.keys[destination].insert(0, value)
+        return value
+
+    @redis_command('RPUSH')
+    def execute_rpush(self, key: (MUTABLE_KEY, KEY_LIST), *args):
+        """
+        Insert all the specified values at the tail of the list stored at
+        key. If key does not exist, it is created as empty list before
+        performing the push operation. When key holds a value that is
+        not a list, an error is returned.
+
+        It is possible to push multiple elements using a single
+        command call just specifying multiple arguments at the end of
+        the command. Elements are inserted one after the other to the
+        tail of the list, from the leftmost element to the rightmost
+        element. So for instance the command RPUSH mylist a b c will
+        result into a list containing a as first element, b as second
+        element and c as third element.
+
+        Return value:
+          Integer reply: the length of the list after the push
+          operation.
+        """
+        if not key in self.keys:
+            self.keys[key] = list()
+        elif not type(self.keys[key]) is list:
+            return resp.Errors.WRONGTYPE
+        self.keys[key] += list(args)
+        return len(self.keys[key])
+
+    @redis_command('RPUSHX')
+    def execute_rpushx(self, key: (MUTABLE_KEY, KEY_LIST), *args):
+        """
+        Inserts value at the tail of the list stored at key, only if key
+        already exists and holds a list. In contrary to RPUSH, no
+        operation will be performed when key does not yet exist.
+
+        Return value:
+          Integer reply: the length of the list after the push
+          operation.
+        """
+        if not key in self.keys:
+            return resp.NIL
+        self.execute_rpush(key, *args)

--- a/rediserver/resp.py
+++ b/rediserver/resp.py
@@ -14,6 +14,7 @@ class Errors:
     INVALID_CURSOR = Error('ERR', 'invalid cursor')
     NOT_INT = Error('ERR', 'value is not an integer or out of range')
     WRONGTYPE = Error('WRONGTYPE', 'Operation against a key holding the wrong kind of value')
+    KEYERROR = Error('KEYERROR', 'Key not found')
 
 
 async def read_command(reader):

--- a/tests/test_lists.py
+++ b/tests/test_lists.py
@@ -1,0 +1,159 @@
+# placeholder for properly-structured tests ... these just
+# back-channel the list/set logic of the added functions
+
+if False:
+
+    R = rediserver.redis.Redis()
+    
+    # verify type-based errors
+    R.execute_sadd('someset', 1)
+    for f0 in (R.execute_llen, R.execute_lpop, R.execute_rpop,):
+        try:
+            f0('someset')
+            raise ValueError("Oops!")
+        except Exception as err:
+            if not 'WRONGTYPE' in str(err):
+                raise err
+    for f1 in (R.execute_lindex, R.execute_lpush, R.execute_lpushx, R.execute_rpush, R.execute_rpushx):
+        try:
+            f1('someset', 1)
+            raise ValueError("Oops!")
+        except Exception as err:
+            if not 'WRONGTYPE' in str(err):
+                raise err
+    for f2 in (R.execute_lrange, R.execute_lrem, R.execute_lset, R.execute_ltrim):
+        try:
+            f2('someset', 1, 2)
+            raise ValueError("Oops!")
+        except Exception as err:
+            if not 'WRONGTYPE' in str(err):
+                raise err
+    for f in (R.execute_rpoplpush,):
+        try:
+            f('someset', 'a', 'b')
+            raise ValueError("Oops!")
+        except Exception as err:
+            if not 'WRONGTYPE' in str(err):
+                raise err
+    for f in (R.execute_linsert,):
+        try:
+            f('someset', 1, 2)
+            raise ValueError("Oops!")
+        except Exception as err:
+            if not 'WRONGTYPE' in str(err):
+                raise err
+    
+    assert R.execute_lpush('quux', 11) == 1
+    assert R.execute_lpush('quux', 12) == 2
+    assert R.execute_lpush('quux', 13) == 3
+    assert R.keys['quux'] == [13,12,11]
+    del(R.keys['quux'])
+    
+    assert R.execute_rpush('quux', 11) == 1
+    assert R.execute_rpush('quux', 12) == 2
+    assert R.execute_rpush('quux', 13) == 3
+    assert R.keys['quux'] == [11,12,13]
+    del(R.keys['quux'])
+    
+    assert R.execute_rpush('quux', 11) == 1
+    assert R.execute_lpush('quux', 12) == 2
+    assert R.execute_rpush('quux', 13) == 3
+    assert R.keys['quux'] == [12,11,13]
+    del(R.keys['quux'])
+    
+    # multi-push
+    assert R.execute_lpush('quux', 11, 12, 13) == 3
+    assert R.keys['quux'] == [11,12,13]
+    
+    ### INDEXING
+    assert R.execute_lindex('quux', 0) == 11
+    assert R.execute_lindex('quux', 2) == 13
+    assert R.execute_lindex('quux', 3) is None
+    assert R.execute_lindex('quux', -1) == 13
+    assert R.execute_lindex('quux', -3) is None
+    assert R.keys['quux'] == [11, 12, 13]
+    ### INSERTION
+    # not present, no change
+    assert R.execute_linsert('quux', 'before', 0, 99) is None
+    assert R.keys['quux'] == [11, 12, 13]
+    # should find these
+    assert R.execute_linsert('quux', 'before', 12, 99) == 4
+    assert R.keys['quux'] == [11, 99, 12, 13]
+    assert R.execute_linsert('quux', 'after', 11, 88) == 5
+    assert R.keys['quux'] == [11, 88, 99, 12, 13]
+    ### LENGTH
+    assert R.execute_llen('undef') == 0
+    assert R.execute_llen('quux') == 5
+    ### POPs
+    assert R.execute_lpop('quux') == 11
+    assert R.keys['quux'] == [88, 99, 12, 13]
+    assert R.execute_rpop('quux') == 13
+    assert R.keys['quux'] == [88, 99, 12]
+    # empties
+    assert R.execute_lpop('undef') is None
+    assert R.execute_rpop('undef') is None
+    ### PUSHX
+    assert R.execute_lpushx('undef', 1) is None
+    assert not 'undef' in R.keys
+    assert R.execute_rpushx('undef', 1) is None
+    assert not 'undef' in R.keys
+    del(R.keys['quux'])
+    ### LRANGE
+    R.execute_rpush('quux', *list(range(20, 25)))
+    assert R.execute_lrange('quux', 0, 2) == [20, 21, 22]
+    assert R.execute_lrange('quux', 0, 99) == [20, 21, 22, 23, 24]
+    assert R.execute_lrange('quux', -2, 99) == [23, 24]
+    assert R.execute_lrange('quux', -2, -1) == [23, 24]
+    del(R.keys['quux'])
+    
+    ### LREM
+    del(R.keys['quux'])
+    R.execute_rpush('quux', 11, 11, 12, 12, 13, 13, 14, 14, 13, 13, 12, 12, 11, 11)
+    assert R.execute_lrem('quux', 1, 11) == 1
+    assert R.keys['quux'] == [    11, 12, 12, 13, 13, 14, 14, 13, 13, 12, 12, 11, 11]
+    assert R.execute_lrem('quux', -2, 11) == 2
+    assert R.keys['quux'] == [    11, 12, 12, 13, 13, 14, 14, 13, 13, 12, 12,       ]
+    assert R.execute_lrem('quux', 0, 11) == 1
+    assert R.keys['quux'] == [        12, 12, 13, 13, 14, 14, 13, 13, 12, 12,       ]
+    assert R.execute_lrem('quux', -3, 12) == 3
+    assert R.keys['quux'] == [        12,     13, 13, 14, 14, 13, 13,               ]
+    assert R.execute_lrem('quux', 0, 13) == 4
+    assert R.keys['quux'] == [        12,             14, 14,                       ]
+    
+    ### LSET
+    del(R.keys['quux'])
+    R.execute_rpush('quux', 11, 12, 13, 14, 15, 16, 17, 18,)
+    assert R.execute_lset('quux', 2, 99) == rediserver.resp.OK
+    assert R.keys['quux'] == [ 11, 12, 99, 14, 15, 16, 17, 18, ]
+    assert R.execute_lset('quux', -1, 98) == rediserver.resp.OK
+    assert R.keys['quux'] == [ 11, 12, 99, 14, 15, 16, 17, 98, ]
+    assert R.execute_lset('quux', 1000, 97) == rediserver.resp.Errors.NOT_INT
+    
+    ### LTRIM
+    del(R.keys['quux'])
+    R.execute_rpush('quux', 11, 12, 13, 14, 15, 16)
+    assert R.execute_ltrim('quux', 0, 2) == rediserver.resp.OK
+    assert R.keys['quux'] == [11, 12, 13]
+    del(R.keys['quux'])
+    R.execute_rpush('quux', 11, 12, 13, 14, 15, 16)
+    assert R.execute_ltrim('quux', -3, -1) == rediserver.resp.OK
+    assert R.keys['quux'] == [14, 15, 16]
+    del(R.keys['quux'])
+    R.execute_rpush('quux', 11, 12, 13, 14, 15, 16)
+    assert R.execute_ltrim('quux', 3, 999) == rediserver.resp.OK
+    assert R.keys['quux'] == [14, 15, 16]
+    del(R.keys['quux'])
+    R.execute_rpush('quux', 11, 12, 13, 14, 15, 16)
+    assert R.execute_ltrim('quux', -2, 999) == rediserver.resp.OK
+    assert R.keys['quux'] == [15, 16]
+    del(R.keys['quux'])
+    
+    # RPOPLPUSH
+    R.execute_rpush('src', 11, 12, 13)
+    R.execute_rpush('dest', 31, 32, 33)
+    assert R.keys['src'] == [11, 12, 13]
+    assert R.keys['dest'] == [31, 32, 33]
+    assert R.execute_rpoplpush('src', 'dest') == 13
+    assert R.keys['src'] == [11, 12]
+    assert R.keys['dest'] == [13, 31, 32, 33]
+    


### PR DESCRIPTION
Thanks for the basic functionality! I have use for ordered pubsub queues, so I wanted to add list operations to the functions available. I started with https://redis.io/commands#list and skipped "blocking" functions.

Redis functions implemented: `LINDEX`, `LINSERT`, `LLEN`, `LPOP`, `LPUSH`, `LPUSHX`, `LRANGE`, `LREM`, `LSET`, `LTRIM`, `RPOP`, `RPOPLPUSH`, `RPUSH`, `RPUSHX`.

NB: I added crude tests, mostly due to time and infamiliarity with `pytest` and the existing structure. While they work, it's likely they could be improved or at least formalized better than I've done here. They are not automatically run, ready at the moment for manual/interactive testing.